### PR TITLE
Feat: Add Support for Hidden Fields on Tabs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ class Tabs extends React.Component {
   };
 
   getTabFields = tabName => {
-    return this.props.type.fields.filter(f => f.fieldset == tabName);
+    return this.props.type.fields.filter(f => f.fieldset == tabName && f.type.hidden !== true);
   };
 
   flattenFields = arr => {


### PR DESCRIPTION

This itsy-bitsy PR adds support for the `hidden` property in field definitions. 

closes #9 