### PR TITLE
Fix missing props not passed down to field builder (fixes #13)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -167,8 +167,9 @@ class Tabs extends React.Component {
       readOnly,
       focusPath,
       value,
-      type
-    } = this.props
+      type,
+      ...otherProps
+    } = this.props;
     const tabFields = this.getActiveTabFields();
 
     let contentStyle = styles.content_document;
@@ -222,6 +223,7 @@ class Tabs extends React.Component {
               var fieldValue = value && value[field.name] ? value[field.name] : undefined;
 
               var fieldProps = {
+                ...otherProps,
                 ref: fieldRef,
                 type: fieldType,
                 markers: fieldMarkers,


### PR DESCRIPTION
Hi!

I had a bug with the latest version where the `filterFields` prop wasn't being passed down anymore to the field builder.
I fixed it by passing down every "rest props" down to it. Notice that I kept the `...otherProps` on top, so whatever prop you were overriding should stay as it is and hopefully this fix shouldn't break anything else.

Thanks!