### PR TITLE
incorrect path

### DIFF
--- a/sanity.json
+++ b/sanity.json
@@ -10,7 +10,7 @@
     },
     {
       "implements": "part:@sanity/form-builder/input/tabs",
-      "path": "src/index.js"
+      "path": "index.js"
     }
   ]
 }


### PR DESCRIPTION
Fixes issue where running ```sanity check``` returns an error.

```Error:  * Part "part:@sanity/form-builder/input/tabs" was attempted to be implemented by "/repository-location/studio/node_modules/sanity-plugin-tabs/lib/src/index.js"```

implements path should be relative to source/compiled path in first paths object.