### PR TITLE
Hide fieldsets with only hidden fields

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,10 +190,11 @@ class Tabs extends React.Component {
     var fieldSets = [];
     if (
       type.fieldsets &&
-      type.fieldsets.length > 0 &&
       type.fieldsets[0].single !== true
     ) {
-      fieldSets = type.fieldsets.sort((a, b) => {
+      fieldSets = type.fieldsets.filter((fs) => 
+        (fs.fields ?? [fs.field]).some((field) => field.type.hidden !== true)
+      ).sort((a, b) => {
         if (a.options && b.options) {
           return a.options.sortOrder - b.options.sortOrder;
         }


### PR DESCRIPTION
If all of the fields in a fieldset are hidden, ignore that fieldset.

https://github.com/azzlack/sanity-plugin-tabs/issues/31

---

I removed the check for if the length is greater than 0.

If it's an empty array, then after filtering and sorting it will still
be an empty array. Which is the initial value of `fieldSets`, so no
change.