### PR TITLE
fix: set isRoot to false

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -288,6 +288,7 @@ class Tabs extends React.Component {
                 focusPath: focusPath,
                 readOnly: fieldReadOnly,
                 value: fieldValue,
+                isRoot: false,
                 onFocus: (path) => this.onFieldFocusHandler(field, path),
                 onChange: (patchEvent) =>
                   this.onFieldChangeHandler(field, patchEvent),


### PR DESCRIPTION
This is a simple fix to help Sanity propagate error markers. Particularly to content blocks. By prop spreading it's inheriting true. This causes sanity to return the markers as is without mapping them. Then the markers the content block receives aren't valid for that block and get ignored. Essentially stopping validation errors and warnings from being displayed.

It should be safe to assume false. Sanity's usage in some components checks path length to determine root `const isRoot = path.length === 0` . Since we're always setting a path value of one `var fieldPath = [field.name];` it should be safe to assume the input is not root.


```javascript
// packages/@sanity/form-builder/src/FormBuilderInput.tsx
const childMarkers = useMemo(() => {
    if (isRoot) return markers
    return markers
      .filter((marker) => PathUtils.startsWith(path, marker.path))
      .map((marker) => ({
        ...marker,
        path: PathUtils.trimChildPath(path, marker.path),
      }))
  }, [isRoot, markers, path])
```

With the fix get UI errors in the content block and in the modal.
<img width="687" alt="Screen Shot 2021-09-06 at 9 27 40 am" src="https://user-images.githubusercontent.com/1826459/132144496-32405606-a60a-4d4b-ae84-46ecd91e1972.png">
