### PR TITLE
Disable debug logging by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,111 +4,112 @@ Input component for rendering fieldsets as tabs
 
 [![NPM version](https://img.shields.io/npm/v/sanity-plugin-tabs?style=for-the-badge)](https://www.npmjs.com/package/sanity-plugin-tabs) [![NPM Downloads](https://img.shields.io/npm/dw/sanity-plugin-tabs?style=for-the-badge)](https://www.npmjs.com/package/sanity-plugin-tabs)
 
-### Compatibility
+## Compatibility
+
 | Package Version | Sanity Version |
-| --- | --- |
-| 2.0.x | 2.0.x |
-| 1.4.x | 1.150.x |
+| --------------- | -------------- |
+| 2.0.x           | 2.0.x          |
+| 1.4.x           | 1.150.x        |
 
-### How does it look?
+## How does it look?
 
-![Preview](/images/previews.png?raw=true "Preview")
+![Preview](/images/previews.png?raw=true 'Preview')
 
-### Demo
+## Demo
+
 Clone the original [demo repository](https://github.com/azzlack/sanity-plugin-tabs-demo) and run `sanity start` to see how it works.
 
-### How do I use it?
+## How do I use it?
 
 Just add `inputComponent: Tabs` to your field. Please note that the field type must be `object`.
 
-```
-import Tabs from "sanity-plugin-tabs"
+```javascript
+import Tabs from 'sanity-plugin-tabs';
 
 export default {
-  type: "document",
-  title: `Frontpage`,
-  name: `frontpage`,
+  type: 'document',
+  title: `Front Page`,
+  name: `frontPage`,
   fields: [
     {
-      name: "content",
-      type: "object",
+      name: 'content',
+      type: 'object',
       inputComponent: Tabs,
 
       fieldsets: [
-        { name: "main", title: "Main", options: { sortOrder: 10 } },
-        { name: "aside", title: "Aside", options: { sortOrder: 20 } },
-        { name: "meta", title: "Meta", options: { sortOrder: 30 } },
+        { name: 'main', title: 'Main', options: { sortOrder: 10 } },
+        { name: 'aside', title: 'Aside', options: { sortOrder: 20 } },
+        { name: 'meta', title: 'Meta', options: { sortOrder: 30 } },
       ],
       options: {
         // setting layout to object will group the tab content in an object fieldset border.
         // ... Useful for when your tab is in between other fields inside a document.
-        layout: "object"
+        layout: 'object',
       },
 
       fields: [
         {
-          type: "object",
-          name: "mainTitle",
-          title: "Main Title",
-          fieldset: "main",
+          type: 'object',
+          name: 'mainTitle',
+          title: 'Main Title',
+          fieldset: 'main',
 
-          fieldsets: [
-            { name: "ingress", title: "Ingress" },
-          ],
+          fieldsets: [{ name: 'ingress', title: 'Ingress' }],
 
           fields: [
             {
-              type: "string",
-              name: "header",
-              title: "Header"
+              type: 'string',
+              name: 'header',
+              title: 'Header',
             },
             {
-              type: "string",
-              name: "ingressText",
-              title: "Text",
-              fieldset: "ingress"
+              type: 'string',
+              name: 'ingressText',
+              title: 'Text',
+              fieldset: 'ingress',
             },
-          ]
+          ],
         },
         {
-          type: "string",
-          name: "info",
-          title: "Information",
-          fieldset: "aside"
+          type: 'string',
+          name: 'info',
+          title: 'Information',
+          fieldset: 'aside',
         },
         {
-          type: "object",
-          name: "aside",
-          fieldset: "meta",
+          type: 'object',
+          name: 'aside',
+          fieldset: 'meta',
           inputComponent: Tabs,
 
           fieldsets: [
-            { name: "tags", title: "Tags" },
-            { name: "categories", title: "Categories" },
+            { name: 'tags', title: 'Tags' },
+            { name: 'categories', title: 'Categories' },
           ],
 
           fields: [
             {
-              type: "string",
-              name: "contentType",
-              title: "Content Type",
-              fieldset: "tags"
+              type: 'string',
+              name: 'contentType',
+              title: 'Content Type',
+              fieldset: 'tags',
             },
             {
-              type: "string",
-              name: "category",
-              title: "Category",
-              fieldset: "categories"
+              type: 'string',
+              name: 'category',
+              title: 'Category',
+              fieldset: 'categories',
             },
-          ]
+          ],
         },
-      ]
-    }
-  ]
+      ],
+    },
+  ],
 };
 ```
 
-### Development
+## Development
+
 Run the following commands at the root of this repository.
 
 ```
@@ -116,7 +117,38 @@ npm i
 npm link
 ```
 
-Now you can start developing the plugin.  
-To include it in your Sanity test site, navigate to the root folder of your cms project and run `npm link sanity-plugin-tabs`. You will now reference the local version of the when using `import Tabs from "sanity-plugin-tabs"` in your files.  
+Now you can start developing the plugin.
 
-To debug the plugin files in you then need to run `sanity start --preserve-symlinks` in your cms project, and `npm run dev` in your sanity-plugin-tabs repository folder.
+To include it in your Sanity test site, navigate to the root folder of your CMS project and run:
+
+```
+npm link sanity-plugin-tabs
+```
+
+You will now reference the local version of the plugin when importing it as below:
+
+```javascript
+import Tabs from 'sanity-plugin-tabs';
+```
+
+### Debugging
+
+To debug the plugin files in you then need to start Sanity with the flag `--preserve-symlinks` as in the command below:
+
+```
+sanity start --preserve-symlinks
+```
+
+And then from the `sanity-plugin-tabs` repository folder, run the project with:
+
+```
+npm run dev
+```
+
+Logging from the plugin is disabled by default, so if you'd like to see more detailed debug information, set the environment variable:
+
+```
+SANITY_STUDIO_PLUGIN_TABS_DEBUG=true
+```
+
+This can be easily done by creating a file called `.env.development` next to your project's `sanity.json` and adding the line above to that file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-plugin-tabs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import {
   FormBuilderInput,
   patches,
 } from 'part:@sanity/form-builder';
-import { resolveTypeName } from './utils';
+import { log, resolveTypeName } from './utils';
 import InvalidValue from '@sanity/form-builder/lib/inputs/InvalidValueInput';
 import * as PathUtils from '@sanity/util/paths.js';
 import ErrorOutlineIcon from 'part:@sanity/base/error-outline-icon';
@@ -45,7 +45,7 @@ class Tabs extends React.Component {
     } else {
     }
 
-    console.debug(`[Tabs] Focus`);
+    log(`[Tabs] Focus`);
   };
 
   getTabFields = (tabName) => {
@@ -112,7 +112,7 @@ class Tabs extends React.Component {
   onFieldBlurHandler = (field) => {
     const { onBlur, type } = this.props;
 
-    console.debug(`[Tabs] FieldBlurred:`, field);
+    log(`[Tabs] FieldBlurred:`, field);
 
     if (onBlur) {
       onBlur();
@@ -122,7 +122,7 @@ class Tabs extends React.Component {
   onFieldFocusHandler = (field, path) => {
     const { onFocus, type } = this.props;
 
-    console.debug(`[Tabs] FieldFocused:`, field, path);
+    log(`[Tabs] FieldFocused:`, field, path);
 
     if (onFocus) {
       onFocus(path);
@@ -137,7 +137,7 @@ class Tabs extends React.Component {
         .prefixAll(field.name)
         .prepend(setIfMissing({ _type: type.name }));
 
-      console.debug(`[Tabs] FieldChanged:`, field, e);
+      log(`[Tabs] FieldChanged:`, field, e);
 
       if (onChange) {
         onChange(e);
@@ -169,7 +169,7 @@ class Tabs extends React.Component {
   }
 
   render = () => {
-    console.debug(`[Tabs] Props:`, this.props);
+    log(`[Tabs] Props:`, this.props);
 
     const {
       level,

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,3 +56,9 @@ export function resolveTypeName(value) {
   const jsType = resolveJSType(value);
   return (jsType === 'object' && '_type' in value && value._type) || jsType;
 }
+
+export function log(message, ...args) {
+  if (process.env.SANITY_STUDIO_PLUGIN_TABS_DEBUG === 'true') {
+    console.debug(message, args);
+  }
+}


### PR DESCRIPTION
At work, we use this plugin basically in every new Sanity document we create and I noticed that the `console.debug`s that come from the plugin slow down the browser quite heavily when the dev console is open, to the point that it's almost impossible to try and debug our own code or even use Sanity at all.

So my suggestion here is to disable any logging by default and add an option to enable it on demand with an environment variable called `SANITY_STUDIO_PLUGIN_TABS_DEBUG`. If I'm not mistaken, according to the Sanity documentation, only env variables that are prepended with `SANITY_STUDIO_` are picked up and added to the JS bundle (https://www.sanity.io/docs/studio-environment-variables#f5e9e3158896). I've tested this with a test Sanity project and it worked well.

I've also added some small improvements to the `README` and included instructions on how to activate the logging.

Just tell me if you like this suggestion, and if I should change anything.

Thanks for the plugin! 🙂