### PR TITLE
Fix: InvalidValueInput from @sanity/form-builder is no longer a default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Run the following commands at the root of this repository.
 
 ```
 npm i
+npm run build
 npm link
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import {
 } from 'part:@sanity/form-builder';
 import { Grid } from '@sanity/ui'
 import { log, resolveTypeName } from './utils';
-import InvalidValue from '@sanity/form-builder/lib/inputs/InvalidValueInput';
+import { InvalidValueInput } from '@sanity/form-builder/lib/inputs/InvalidValueInput';
 import * as PathUtils from '@sanity/util/paths.js';
 import ErrorOutlineIcon from 'part:@sanity/base/error-outline-icon';
 import WarningOutlineIcon from 'part:@sanity/base/warning-outline-icon';
@@ -358,7 +358,7 @@ class Tabs extends React.Component {
                     if (expectedType !== actualType && !isCompatible) {
                       return (
                         <div {...fieldWrapperProps}>
-                          <InvalidValue
+                          <InvalidValueInput
                             value={fieldValue}
                             onChange={fieldProps.onChange}
                             validTypes={[fieldType.name]}


### PR DESCRIPTION
As of v2.12.0: https://github.com/sanity-io/sanity/commit/f317fd8c86db8fe20d2d579f391e3e0adff5a378

This causes the Tabs plugin to break in Sanity if the invalid input branch is reached - as the import is undefined:

`Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
`

This PR changes the import to a named import.